### PR TITLE
Dependabot のバージョン更新を有効にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot 設定
+# https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+#
+# これまで dependabot.yml が無く、Dependabot alerts 起点のセキュリティ更新しか
+# 動いていなかったため、バージョン更新も定期的に回すようにする。
+#
+# 依存はすべて devDependencies（pug / sass / postcss まわりのビルド道具）で、
+# ブラウザへ配るものは無い。ワークフローは無いので github-actions は含めていない。
+# 追加したときはこのファイルにもエントリを足すこと。
+#
+# 方針: minor/patch はグループ化して 1 PR にまとめ、major は個別 PR で判断する。
+#       リリース直後の不具合や yank を踏まないよう cooldown で寝かせてから PR を出す。
+
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------------
+  # npm
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 何をしたか

`dependabot.yml` を新しく置きました。

これまで設定ファイルが無く、alerts 起点のセキュリティ更新しか動いていませんでした。`package.json` があるので、バージョン更新も回すようにします。

依存はすべて devDependencies（pug / sass / postcss まわりのビルド道具）で、ブラウザへ配るものはありません。ワークフローが無いため github-actions は含めていません。
## 背景

2026-08-15 に CALIL org の active 132 リポジトリを横断で棚卸しし、`dependabot.yml` が宣言しているエコシステムと、実際に置かれているマニフェストをディレクトリ単位で突き合わせました。その結果、設定はあるのに一部のエコシステムだけ対象から漏れているリポジトリが 8 件、設定ファイル自体が無いものが 1 件見つかりました。ndc-dev org でも 2 件見つかっています。この PR はその一部です。

Cordova が展開した `plugins/*`、workspaces のモノレポの子 `package.json`、`uv export` が生成する `requirements.txt` は対象にすべきでないと判断して除いています。

## 確認したこと

- YAML としてパースでき、`updates` の各エントリが意図した (エコシステム, ディレクトリ) になっていること
- `github-actions` と `terraform` で `semver-major-days` を使っていないこと。これらは指定すると設定ファイル全体が弾かれ、Dependabot がまったく動かなくなります

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SecR8hdLdUCNr4dCXsweAk